### PR TITLE
Add missing export and `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "web-muse",
+  "version": "1.0.0",
+  "description": "A modern JavaScript library for connecting to Muse EEG devices using Web Bluetooth API.",
+  "homepage": "https://github.com/itayinbarr/web-muse#readme",
+  "bugs": {
+    "url": "https://github.com/itayinbarr/web-muse/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/itayinbarr/web-muse.git"
+  },
+  "license": "ISC",
+  "author": "Itay Inbar",
+  "type": "module",
+  "main": "src/lib/MuseDevice.js",
+  "directories": {
+    "doc": "docs",
+    "example": "examples"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/src/lib/CircularBuffer.js
+++ b/src/lib/CircularBuffer.js
@@ -63,3 +63,5 @@ class MuseCircularBuffer {
     }
   }
 }
+
+export { MuseCircularBuffer };

--- a/src/lib/MuseDevice.js
+++ b/src/lib/MuseDevice.js
@@ -1,5 +1,6 @@
 import { MuseCircularBuffer } from "./CircularBuffer";
-class Muse {
+
+export class Muse {
   /**
    * Constructs a new instance of the MuseCircularBuffer class.
    *
@@ -390,6 +391,7 @@ class Muse {
     this.state = 2;
   }
 }
+
 /**
  * Connects to a Muse device and returns the connected Muse object.
  *


### PR DESCRIPTION
When experimenting with this library I noticed two things that caused errors when importing the library as described in the README:
```
import { connectMuse } from "web-muse";
```

This PR fixes these two things: a missing export of `MuseCircularBuffer` and a lack of a `package.json`.